### PR TITLE
Fix the menu construction to display multiple items

### DIFF
--- a/src/Menu/ContentMenuBuilder.php
+++ b/src/Menu/ContentMenuBuilder.php
@@ -57,8 +57,9 @@ final class ContentMenuBuilder
     private function getContentMenu(MenuBuilderEvent $event)
     {
         $adminMenu = $event->getMenu();
+        $contentMenu = $adminMenu->getChild('content');
 
-        if (!($contentMenu = $adminMenu->getChild('content'))) {
+        if (null === $contentMenu) {
             $contentMenu = $adminMenu
                 ->addChild('content')
                 ->setLabel('lakion_sylius_cms.menu.admin.header')

--- a/src/Menu/ContentMenuBuilder.php
+++ b/src/Menu/ContentMenuBuilder.php
@@ -58,10 +58,12 @@ final class ContentMenuBuilder
     {
         $adminMenu = $event->getMenu();
 
-        $contentMenu = $adminMenu
-            ->addChild('content')
-            ->setLabel('lakion_sylius_cms.menu.admin.header')
-        ;
+        if (!($contentMenu = $adminMenu->getChild('content'))) {
+            $contentMenu = $adminMenu
+                ->addChild('content')
+                ->setLabel('lakion_sylius_cms.menu.admin.header')
+            ;
+        }
 
         return $contentMenu;
     }


### PR DESCRIPTION
The CMS menu in Sylius only contained "String blocks". "Routes" and "Static Contents" weren't displayed. This was because the "content" child menu was overridden every time a new entry was created.