### PR TITLE
Also keep route grid working when no static content is linked

### DIFF
--- a/src/Resources/views/Admin/Route/Grid/Field/content.html.twig
+++ b/src/Resources/views/Admin/Route/Grid/Field/content.html.twig
@@ -1,3 +1,3 @@
-{% if data is not same as(null) %}
+{% if data is not null %}
     {{ data.title }}
 {% endif %}

--- a/src/Resources/views/Admin/Route/Grid/Field/content.html.twig
+++ b/src/Resources/views/Admin/Route/Grid/Field/content.html.twig
@@ -1,1 +1,3 @@
-{{ data.title }}
+{% if data is not same as(null) %}
+    {{ data.title }}
+{% endif %}


### PR DESCRIPTION
Mainly it was an issue on my fixtures side, as I forgot to link a StaticContent object to the Route object I was importing. But, as soon as a StaticContent seems gone and the Route cannot find the relation anymore, the grid errors that the `data.title` is not available (data is null). It doesn't harm to add this if statement I think, as it helps to keep the grid running even though there is some content missing somewhere.